### PR TITLE
Allow to use `// @flow` as flow pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ statistics and a big list of files that are and
 are not flow-annotated.
 
 This works by scanning the first 100 characters of
-each file and finding `/* @flow */` comments.
+each file and finding `/* @flow */` or `// @flow` 
+comments.
 
 ## install
 

--- a/are-we-flow-yet
+++ b/are-we-flow-yet
@@ -6,13 +6,25 @@ var base = process.argv[2];
 var buffer = new Buffer(100);
 var files = glob.sync(base + '/**/*.js');
 
+var FLOW_REGEXPS = [
+  /\/\*\s*@flow\s*\*\//g,
+  /\/\/\s+@flow\s+/g,
+  /\/\/\s+@flow$/mg
+];
+
 var flow = [],
   noflow = [];
+
+function hasFlowPragma(string) {
+  return FLOW_REGEXPS.some(function(regExp) {
+    return regExp.test(string);
+  });
+}
 
 files.forEach(function(file) {
   var fd = fs.openSync(file, 'r');
   fs.readSync(fd, buffer, 0, 100);
-  if (buffer.toString().match(/\/\*\s*@flow\s*\*\//g)) {
+  if (hasFlowPragma(buffer.toString())) {
     flow.push(file);
   } else {
     noflow.push(file);

--- a/test.js
+++ b/test.js
@@ -26,3 +26,17 @@ non flow files 0
     t.end();
   });
 });
+
+test('are-we-flow-yet - one-line', function(t) {
+  exec('./are-we-flow-yet test/one-line', function(err, stdout, stderr) {
+    var out = (function() {/*
+flow files 2
+non flow files 1
+------------------
+test/one-line/five.js
+*/}).toString().split('\n').slice(1, -1).join('\n');
+    t.equal(stdout.trim(), out);
+    t.equal(err.code, 1);
+    t.end();
+  });
+});

--- a/test/one-line/five.js
+++ b/test/one-line/five.js
@@ -1,0 +1,2 @@
+// @flows
+module.exports = 1;

--- a/test/one-line/four.js
+++ b/test/one-line/four.js
@@ -1,0 +1,2 @@
+// @flow    
+module.exports = 1;

--- a/test/one-line/three.js
+++ b/test/one-line/three.js
@@ -1,0 +1,2 @@
+// @flow
+module.exports = 1;


### PR DESCRIPTION
It's possible to use `// @flow` comment in order to flow's documentation.
But previous code does not allowed this. So added `// @flow$` and `// @flow\s+`.
`// @flow$`means that there is line ending after `// @flow`.
`// @flow\s+` means that there are whitespace after `// @flow`.